### PR TITLE
Feature/Sort Articles by date desc in category templates

### DIFF
--- a/gatsby-theme-help-center/src/templates/category.tsx
+++ b/gatsby-theme-help-center/src/templates/category.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { Link, graphql } from 'gatsby';
-import { Breadcrumbs, Typography, Card, CardContent } from '@material-ui/core';
-import { Category } from '../types/Category';
-import { MdxArticle } from '../types/Article';
-import { SiteMetadata } from '../types/SiteMetadata';
-import ArticleList from '../components/ArticleList';
-import CategoryLayout from '../layouts/CategoryLayout';
-import { SEO } from '../components/SEO';
+import React from "react";
+import { Link, graphql } from "gatsby";
+import { Breadcrumbs, Typography, Card, CardContent } from "@material-ui/core";
+import { Category } from "../types/Category";
+import { MdxArticle } from "../types/Article";
+import { SiteMetadata } from "../types/SiteMetadata";
+import ArticleList from "../components/ArticleList";
+import CategoryLayout from "../layouts/CategoryLayout";
+import { SEO } from "../components/SEO";
 
 export const query = graphql`
   query($categoryId: String!) {
@@ -24,7 +24,7 @@ export const query = graphql`
         description
       }
     }
-    allMdx {
+    allMdx(sort: { fields: [frontmatter___date], order: DESC }) {
       edges {
         node {
           id
@@ -75,12 +75,12 @@ export default function ({
       <div>
         <Card>
           <CardContent>
-            <Breadcrumbs aria-label="Navigation">
-              <Link to="/">Home</Link>
-              <Typography color="textPrimary">{category.name}</Typography>
+            <Breadcrumbs aria-label='Navigation'>
+              <Link to='/'>Home</Link>
+              <Typography color='textPrimary'>{category.name}</Typography>
             </Breadcrumbs>
             <h1>{category.name}</h1>
-            <Typography variant="body1" component="p" paragraph>
+            <Typography variant='body1' component='p' paragraph>
               {category.description}
             </Typography>
             <ArticleList articles={articles} />

--- a/gatsby-theme-help-center/src/templates/category.tsx
+++ b/gatsby-theme-help-center/src/templates/category.tsx
@@ -45,7 +45,7 @@ export const query = graphql`
 
 export default function ({
   data,
-  pageContext
+  pageContext,
 }: {
   pageContext: { basePath: string };
   data: {
@@ -58,7 +58,7 @@ export default function ({
   const {
     category,
     site: { siteMetadata },
-    allMdx
+    allMdx,
   } = data;
   const articles = allMdx.edges
     .filter((edge) => edge.node.frontmatter.categories.includes(category.slug))

--- a/gatsby-theme-help-center/src/templates/category.tsx
+++ b/gatsby-theme-help-center/src/templates/category.tsx
@@ -1,12 +1,12 @@
-import React from "react";
-import { Link, graphql } from "gatsby";
-import { Breadcrumbs, Typography, Card, CardContent } from "@material-ui/core";
-import { Category } from "../types/Category";
-import { MdxArticle } from "../types/Article";
-import { SiteMetadata } from "../types/SiteMetadata";
-import ArticleList from "../components/ArticleList";
-import CategoryLayout from "../layouts/CategoryLayout";
-import { SEO } from "../components/SEO";
+import React from 'react';
+import { Link, graphql } from 'gatsby';
+import { Breadcrumbs, Typography, Card, CardContent } from '@material-ui/core';
+import { Category } from '../types/Category';
+import { MdxArticle } from '../types/Article';
+import { SiteMetadata } from '../types/SiteMetadata';
+import ArticleList from '../components/ArticleList';
+import CategoryLayout from '../layouts/CategoryLayout';
+import { SEO } from '../components/SEO';
 
 export const query = graphql`
   query($categoryId: String!) {
@@ -45,7 +45,7 @@ export const query = graphql`
 
 export default function ({
   data,
-  pageContext,
+  pageContext
 }: {
   pageContext: { basePath: string };
   data: {
@@ -58,7 +58,7 @@ export default function ({
   const {
     category,
     site: { siteMetadata },
-    allMdx,
+    allMdx
   } = data;
   const articles = allMdx.edges
     .filter((edge) => edge.node.frontmatter.categories.includes(category.slug))
@@ -75,12 +75,12 @@ export default function ({
       <div>
         <Card>
           <CardContent>
-            <Breadcrumbs aria-label='Navigation'>
-              <Link to='/'>Home</Link>
-              <Typography color='textPrimary'>{category.name}</Typography>
+            <Breadcrumbs aria-label="Navigation">
+              <Link to="/">Home</Link>
+              <Typography color="textPrimary">{category.name}</Typography>
             </Breadcrumbs>
             <h1>{category.name}</h1>
-            <Typography variant='body1' component='p' paragraph>
+            <Typography variant="body1" component="p" paragraph>
               {category.description}
             </Typography>
             <ArticleList articles={articles} />

--- a/site/src/pages/how-many-categories-can-i-have.mdx
+++ b/site/src/pages/how-many-categories-can-i-have.mdx
@@ -5,7 +5,7 @@ author: Monica
 categories: ["faqs"]
 date: 2020-03-15
 featured: false
-relatedArticles: ['configuration-options']
+relatedArticles: ["configuration-options"]
 ---
 
 You can create as many categories as you want to. After three categories,

--- a/site/src/pages/how-many-categories-can-i-have.mdx
+++ b/site/src/pages/how-many-categories-can-i-have.mdx
@@ -2,10 +2,10 @@
 title: How many categories can I have?
 description: Is there any limit on the number of categories, how many can I create?
 author: Monica
-categories: ["faqs"]
+categories: ['faqs']
 date: 2020-03-15
 featured: false
-relatedArticles: ["configuration-options"]
+relatedArticles: ['configuration-options']
 ---
 
 You can create as many categories as you want to. After three categories,

--- a/site/src/pages/how-many-categories-can-i-have.mdx
+++ b/site/src/pages/how-many-categories-can-i-have.mdx
@@ -2,7 +2,7 @@
 title: How many categories can I have?
 description: Is there any limit on the number of categories, how many can I create?
 author: Monica
-categories: ['faqs']
+categories: ["faqs"]
 date: 2020-03-15
 featured: false
 relatedArticles: ['configuration-options']


### PR DESCRIPTION
Hello again!

This PR introduces `sort date desc` into the category article list template.

My thinking was:

* The example posts have date fields, which may imply some sort of desire for date order?
* In my usage it would be nice to have a way to organise the posts by date

Counter-thinking

* This is likely a breaking change for existing users if they're "used to" the default random order - (I'm not sure what that is... alphabetical, date the file was created?
* Perhaps this should be configurable in the user's implementation.

Annoyingly I can't get shadowing to work in my usage of this theme. The `themes/colors.ts` is correctly shadowed, but I've tried shadowing files in the components directory and had no luck.

Anyhoo, just thought I'd submit in case you wanted it in there.

Note:

It'd also be possible to filter for posts in a particular category using graphQL, rather than node, if you wanted to:

```js
filter: {
  frontmatter: {
    categories:{
     eq: $categorySlug
    }
  }
}
```